### PR TITLE
Fix bug with saving multi option subsections

### DIFF
--- a/ui/src/components/People/DetailsCard.vue
+++ b/ui/src/components/People/DetailsCard.vue
@@ -31,12 +31,9 @@
             <v-btn
               fab
               class="primary"
-              @click.stop="
-                editing = true;
-                editButton = false;
-              "
               v-show="editButton || edit"
               v-if="data[0]"
+              v-on:click="toggleForm(name)"
             >
               <v-icon>edit</v-icon>
             </v-btn>
@@ -89,6 +86,7 @@
         v-on:successfulSubmit="submit"
         v-on:failedSubmit="showFailedSubmit"
         ref="dynamicEditingForm"
+        :key="dynamicFormKey"
       />
     </v-card-text>
   </v-card>
@@ -207,6 +205,7 @@ export default {
 
                 this.fields = data;
                 this.$refs.dynamicEditingForm.changeFields(data);
+                this.dynamicFormKey++;
               }
             })
             .catch(error => {
@@ -222,6 +221,8 @@ export default {
         show: false,
         type: null
       },
+      currentIndex: null,
+      dynamicFormKey: 0,
       editButton: false,
       editing: false,
       fields: [],
@@ -247,8 +248,22 @@ export default {
       this.$emit(
         "saveData",
         this.$refs.dynamicEditingForm.getInputs(),
-        this.$refs.dynamicEditingForm.getName()
+        this.$refs.dynamicEditingForm.getName(),
+        this.currentIndex
       );
+    },
+    toggleForm(index) {
+      let fields = this.fields;
+
+      fields.forEach(field => {
+        field.value = this.data[index][field.id];
+      });
+
+      this.$refs.dynamicEditingForm.changeFields(fields);
+      this.dynamicFormKey++;
+      this.editing = true;
+      this.editButton = false;
+      this.currentIndex = index;
     }
   },
   props: {

--- a/ui/src/views/People/Edit.vue
+++ b/ui/src/views/People/Edit.vue
@@ -11,6 +11,7 @@
     <v-layout>
       <v-flex xs6 class="pr-3">
         <div v-for="(element, index) in this.practitioner" v-bind:key="index">
+          <h1>subsection-{{ index }}</h1>
           <DetailsCard
             v-if="index != 'id' && index != 'resourceType' && index != 'active'"
             :data="element"
@@ -83,11 +84,16 @@ export default {
 
       this.$refs.alert.reset();
     },
-    saveSubsectionData(data, field) {
+    saveSubsectionData(data, field, index) {
       let component = this;
       let practitioner = this.practitioner;
 
-      practitioner[field] = data;
+      // this is necessary for subsections that can have multiple entries
+      if (index) {
+        practitioner[field][index] = data;
+      } else {
+        practitioner[field] = data;
+      }
 
       axios.put("/practitioner/edit", practitioner).then(response => {
         component.practitioner = practitioner;

--- a/ui/src/views/People/Edit.vue
+++ b/ui/src/views/People/Edit.vue
@@ -11,7 +11,6 @@
     <v-layout>
       <v-flex xs6 class="pr-3">
         <div v-for="(element, index) in this.practitioner" v-bind:key="index">
-          <h1>subsection-{{ index }}</h1>
           <DetailsCard
             v-if="index != 'id' && index != 'resourceType' && index != 'active'"
             :data="element"


### PR DESCRIPTION
This commit fixes a bug where sections that allow multiple entries (IE, name), would bug when try to edit the data. The actual fix ended up being pretty simple and required tracking which of the multiple entries was being edited.