### PR TITLE
Add InfraScan audit workflow for security scanning

### DIFF
--- a/.github/workflows/infrascan.yml
+++ b/.github/workflows/infrascan.yml
@@ -1,0 +1,34 @@
+name: InfraScan Audit
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  infrascan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create Reports Directory
+        run: |
+          mkdir -p infrascan-reports
+          chmod 777 infrascan-reports
+
+      - name: Run InfraScan
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/scan \
+            soldevelo/infrascan:latest \
+            --scanner comprehensive \
+            --format html \
+            --out /scan/infrascan-reports/report.html
+            
+      - name: Upload InfraScan Report
+        uses: actions/upload-artifact@v4
+        if: always() # Upload report even if the scan step fails
+        with:
+          name: infrascan-report
+          path: infrascan-reports/report.html
+          retention-days: 14

--- a/.github/workflows/infrascan.yml
+++ b/.github/workflows/infrascan.yml
@@ -17,13 +17,11 @@ jobs:
           chmod 777 infrascan-reports
 
       - name: Run InfraScan
-        run: |
-          docker run --rm \
-            -v ${{ github.workspace }}:/scan \
-            soldevelo/infrascan:latest \
-            --scanner comprehensive \
-            --format html \
-            --out /scan/infrascan-reports/report.html
+        uses: soldevelo/infrascan@v1.0.6
+        with:
+          scanner: comprehensive
+          format: html
+          out: infrascan-reports/report.html
             
       - name: Upload InfraScan Report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## 📝 Description

This pull request introduces a new GitHub Actions workflow designed to automatically scan infrastructure and code for security vulnerabilities using the **InfraScan** tool. The scanner runs automatically and generates a report in the form of an easy-to-read HTML file.

## 🛠️ Changes

* **New workflow file added:** `.github/workflows/infrascan.yml` has been created.
* **Triggers:** The workflow is configured to run whenever a `push` or `pull_request` event occurs.
* **Steps:**
    1.  **Checkout:** Retrieve the repository code (`actions/checkout@v4`).
    2.  **Reports directory:** Create the `infrascan-reports` directory with the appropriate permissions (777).
    3.  **Scanning:** Launching the Docker container `soldevelo/infrascan:latest` in `comprehensive` mode. The container mounts the workspace and generates a report to the file `/scan/infrascan-reports/report.html`.
    4.  **Report storage:** The generated HTML report is uploaded as an action artefact (`actions/upload-artifact@v4`) under the name `infrascan-report`, and remains accessible for 14 days. The report is saved regardless of whether the scan step completes successfully or fails (`if: always()`).

## ⚙️ Type of change

- [x] ✨ New feature (addition of a new CI tool)
- [x] 🔒 Security enhancement
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring

## 🧪 How to test

1. Create a pull request or push to any branch where this workflow is set up.
2. Go to the **Actions** tab in the GitHub repository.
3. Find the run of the action named **InfraScan Audit**.
4. Ensure that all steps have completed successfully.
5. At the bottom of the action summary, in the ‘Artifacts’ section, you should find a file named `infrascan-report`.
6. Download the artifact, unzip it, and open `report.html` in your browser to verify its contents.